### PR TITLE
Fix vendor path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+composer.lock
+vendor/
+/.php_cs.cache

--- a/src/PHP/CodeStandards/Command/PHPCsFixerGitHookCommand.php
+++ b/src/PHP/CodeStandards/Command/PHPCsFixerGitHookCommand.php
@@ -37,14 +37,20 @@ class PHPCsFixerGitHookCommand extends BaseCommand
         $this->addGitHook($gitPath, $currentFolder . '/../Scripts/git-pre-commit', 'pre-commit');
 
         // Add php-cs-fixer rules to be available on .git folder.
+        $vendorDir = is_dir('../../services/vendor') ? '../../services/vendor' : '../../vendor';
+
         $this->addLinkToGitFolder(
             $gitPath,
-            '../../services/vendor/kununu/scripts/src/PHP/CodeStandards/Scripts/php_cs',
+            sprintf('%s/kununu/scripts/src/PHP/CodeStandards/Scripts/php_cs', $vendorDir),
             '.php_cs'
         );
 
         // Add php-cs-fixer bin to be available on .git folder.
-        $this->addLinkToGitFolder($gitPath, '../../services/vendor/bin/php-cs-fixer', 'php-cs-fixer');
+        $this->addLinkToGitFolder(
+            $gitPath,
+            sprintf('%s/bin/php-cs-fixer', $vendorDir),
+            'php-cs-fixer'
+        );
 
         $output->writeln('<info>' . $this->getName() . '</info> .... Git Hook Applied');
     }


### PR DESCRIPTION
Fix vendor path in order to enable cs fixer on libraries and services that don't follow kununu standard of putting code inside services directory