### PR TITLE
return integer exit codes on all commands

### DIFF
--- a/src/PHP/CodeStandards/Command/PHPCsFixerCodeCommand.php
+++ b/src/PHP/CodeStandards/Command/PHPCsFixerCodeCommand.php
@@ -20,7 +20,7 @@ class PHPCsFixerCodeCommand extends BaseCommand
             ->addArgument(self::ARGUMENT, InputArgument::IS_ARRAY);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $arguments = $input->getArgument(self::ARGUMENT);
         if ($arguments) {
@@ -37,7 +37,10 @@ class PHPCsFixerCodeCommand extends BaseCommand
 
             if (0 != $returnVar) {
                 $output->writeln('<error>Errors occurred please check output</error>');
-            } elseif (count($outputExec)) {
+                return 1;
+            }
+
+            if (count($outputExec)) {
                 $output->writeln('<info>RESULT:</info>');
                 $output->writeln($outputExec, true);
             } else {
@@ -46,5 +49,7 @@ class PHPCsFixerCodeCommand extends BaseCommand
         } else {
             $output->writeln('No files or directories where provided');
         }
+
+        return 0;
     }
 }

--- a/src/PHP/CodeStandards/Command/PHPCsFixerGitHookCommand.php
+++ b/src/PHP/CodeStandards/Command/PHPCsFixerGitHookCommand.php
@@ -15,7 +15,7 @@ class PHPCsFixerGitHookCommand extends BaseCommand
             ->setDescription('Installs PHP CS Fixer Git Pre-Commit Hook');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('<info>' . $this->getName() . '</info> Applying PHP CS Fixer Git Pre-Commit Hook ....');
 
@@ -23,14 +23,14 @@ class PHPCsFixerGitHookCommand extends BaseCommand
         if (0 != $returnVar || !isset($outputExec[0])) {
             $output->writeln('<error>GIT is not available</error>');
 
-            return;
+            return 1;
         }
 
         $gitPath = $outputExec[0] . '/.git';
         if (!is_dir($outputExec[0])) {
             $output->writeln('<error>GIT folder not found at "' . $gitPath . '"</error>');
 
-            return;
+            return 1;
         }
 
         $currentFolder = __DIR__;
@@ -53,6 +53,8 @@ class PHPCsFixerGitHookCommand extends BaseCommand
         );
 
         $output->writeln('<info>' . $this->getName() . '</info> .... Git Hook Applied');
+
+        return 0;
     }
 
     private function addGitHook(string $gitPath, string $file, string $hookName): void


### PR DESCRIPTION
reason:
psalm integration on github exists with this error:
```
Return value of "Kununu\Scripts\PHP\CodeStandards\Command\PHPCsFixerGitHookCommand::execute()" must be of the type int, "null" returned.
```