### PR TITLE
Force import of global classes

### DIFF
--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -25,7 +25,6 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        'array_syntax' => ['syntax' => 'short'],
         'combine_consecutive_unsets' => true,
         'heredoc_to_nowdoc' => true,
         'no_extra_blank_lines' => ['tokens' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block']],
@@ -33,8 +32,9 @@ return (new PhpCsFixer\Config())
         'no_unreachable_default_argument_value' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'ordered_imports' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
         'phpdoc_order' => true,
+	    'global_namespace_import' => ['import_classes' => true],
         'function_declaration' => ['closure_function_spacing' => 'none'],
         'ternary_to_null_coalescing' => true,
         'array_indentation' => true,
@@ -51,6 +51,9 @@ return (new PhpCsFixer\Config())
         'increment_style' => [],
         'method_chaining_indentation' => false,
         'visibility_required' => ['elements' => ['property', 'method']],
+        'self_static_accessor' => true,
+        'no_trailing_whitespace_in_string' => false,
+        'return_assignment' => true,
     ])
     ->setFinder($finder)
 ;


### PR DESCRIPTION
Remove automatic trailing of whitespaces on strings (can break code that relies on those whitespaces)