### PR TITLE
Revert "Fix arrow functions space after fn (#20)"

### DIFF
--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -35,7 +35,7 @@ return (new PhpCsFixer\Config())
         'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
         'phpdoc_order' => true,
 	    'global_namespace_import' => ['import_classes' => true],
-        'function_declaration' => ['closure_function_spacing' => 'none', 'closure_fn_spacing' => 'none'],
+        'function_declaration' => ['closure_function_spacing' => 'none'],
         'ternary_to_null_coalescing' => true,
         'array_indentation' => true,
         'blank_line_after_opening_tag' => false,


### PR DESCRIPTION
This reverts commit d79a2bc015973081841f0f53f05113270b57ce3d.

- Until this library drop supports for PHP 7.x we can not update php-cs-fixer to a version that supports the fix introduced in #20 