### PR TITLE
Drop support for PHP 7.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @hugo-goncalves-kununu @joaoalves-kununu
+* @kununu/opensource-backend
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 vendor/
 .php-cs-fixer.php.cache
 .php_cs.cache
+.php-cs-fixer.cache

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[open.source@kununu.com](mailto:open.source@kununu.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,32 @@
 {
-    "name": "kununu/scripts",
-    "description": "Composer plugin to check code standards the kununu way",
-    "type": "composer-plugin",
-    "keywords": ["standards", "development"],
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Tiago Pinheiro",
-            "email": "tiago.pinheiro@kununu.com"
-        }
-    ],
-    "require": {
-        "php": ">=7.1.0",
-        "composer-plugin-api": "^1.1 | ^2.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
-    },
-    "extra": {
-        "class": "Kununu\\Scripts\\PHP\\CodeStandards\\ScriptsPlugin"
-    },
-    "autoload": {
-        "psr-4": {
-            "Kununu\\Scripts\\": "src/"
-        }
+  "name": "kununu/scripts",
+  "description": "Composer plugin to check code standards the kununu way",
+  "type": "composer-plugin",
+  "keywords": [
+    "standards",
+    "development"
+  ],
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Tiago Pinheiro",
+      "email": "tiago.pinheiro@kununu.com"
     }
+  ],
+  "require": {
+    "php": ">=8.0",
+    "composer-plugin-api": "^2.0",
+    "friendsofphp/php-cs-fixer": "^3.0"
+  },
+  "require-dev": {
+    "composer/composer": "^2.0"
+  },
+  "extra": {
+    "class": "Kununu\\Scripts\\PHP\\CodeStandards\\ScriptsPlugin"
+  },
+  "autoload": {
+    "psr-4": {
+      "Kununu\\Scripts\\": "src/"
+    }
+  }
 }

--- a/src/PHP/CodeStandards/Command/PHPCsFixerCodeCommand.php
+++ b/src/PHP/CodeStandards/Command/PHPCsFixerCodeCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kununu\Scripts\PHP\CodeStandards\Command;
 
@@ -7,14 +8,15 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PHPCsFixerCodeCommand extends BaseCommand
+final class PHPCsFixerCodeCommand extends BaseCommand
 {
     /** This can be a list of files or directories. */
     private const ARGUMENT = 'files';
 
     protected function configure(): void
     {
-        $this->setName('kununu:cs-fixer-code')
+        $this
+            ->setName('kununu:cs-fixer-code')
             ->setAliases(['cs-fixer-code'])
             ->setDescription('Applies PHP CS Fixer on a project folder or file')
             ->addArgument(self::ARGUMENT, InputArgument::IS_ARRAY);
@@ -24,10 +26,8 @@ class PHPCsFixerCodeCommand extends BaseCommand
     {
         $arguments = $input->getArgument(self::ARGUMENT);
         if ($arguments) {
-            $outputExec = $returnVar = null;
-
             $files = implode(' ', $arguments);
-            $vendorDir = $this->getComposer()->getConfig()->get('vendor-dir');
+            $vendorDir = $this->requireComposer()->getConfig()->get('vendor-dir');
 
             exec(
                 $vendorDir . '/bin/php-cs-fixer fix --config ' . __DIR__ . '/../Scripts/php_cs ' . $files,
@@ -37,12 +37,13 @@ class PHPCsFixerCodeCommand extends BaseCommand
 
             if (0 != $returnVar) {
                 $output->writeln('<error>Errors occurred please check output</error>');
+
                 return 1;
             }
 
             if (count($outputExec)) {
                 $output->writeln('<info>RESULT:</info>');
-                $output->writeln($outputExec, true);
+                $output->writeln($outputExec);
             } else {
                 $output->writeln('<info>No files where affected</info>');
             }

--- a/src/PHP/CodeStandards/Command/PHPCsFixerGitHookCommand.php
+++ b/src/PHP/CodeStandards/Command/PHPCsFixerGitHookCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Kununu\Scripts\PHP\CodeStandards\Command;
 
@@ -6,11 +7,12 @@ use Composer\Command\BaseCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PHPCsFixerGitHookCommand extends BaseCommand
+final class PHPCsFixerGitHookCommand extends BaseCommand
 {
     protected function configure(): void
     {
-        $this->setName('kununu:cs-fixer-git-hook')
+        $this
+            ->setName('kununu:cs-fixer-git-hook')
             ->setAliases(['cs-fixer-git-hook'])
             ->setDescription('Installs PHP CS Fixer Git Pre-Commit Hook');
     }
@@ -34,7 +36,7 @@ class PHPCsFixerGitHookCommand extends BaseCommand
         }
 
         $currentFolder = __DIR__;
-        $this->addGitHook($gitPath, $currentFolder . '/../Scripts/git-pre-commit', 'pre-commit');
+        $this->addGitHook($gitPath, $currentFolder . '/../Scripts/git-pre-commit');
 
         // Add php-cs-fixer rules to be available on .git folder.
         $vendorDir = is_dir(sprintf('%s/services/vendor', $outputExec[0])) ? '../../services/vendor' : '../../vendor';
@@ -57,14 +59,14 @@ class PHPCsFixerGitHookCommand extends BaseCommand
         return 0;
     }
 
-    private function addGitHook(string $gitPath, string $file, string $hookName): void
+    private function addGitHook(string $gitPath, string $file): void
     {
         $hooksDir = $gitPath . '/hooks';
         if (!is_dir($hooksDir)) {
             mkdir($hooksDir);
         }
 
-        $hookPath = $hooksDir . '/' . $hookName;
+        $hookPath = $hooksDir . '/pre-commit';
         if (is_file($hookPath)) {
             unlink($hookPath);
         }

--- a/src/PHP/CodeStandards/PHPCsFixerCommandProvider.php
+++ b/src/PHP/CodeStandards/PHPCsFixerCommandProvider.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types=1);
 
 namespace Kununu\Scripts\PHP\CodeStandards;
 
-use Composer\Plugin\Capability\CommandProvider as CommandProviderCapability;
+use Composer\Plugin\Capability\CommandProvider;
 use Kununu\Scripts\PHP\CodeStandards\Command\PHPCsFixerCodeCommand;
 use Kununu\Scripts\PHP\CodeStandards\Command\PHPCsFixerGitHookCommand;
 
-class PHPCsFixerCommandProvider implements CommandProviderCapability
+final class PHPCsFixerCommandProvider implements CommandProvider
 {
-    public function getCommands()
+    public function getCommands(): array
     {
         return [
             new PHPCsFixerCodeCommand(),

--- a/src/PHP/CodeStandards/README.md
+++ b/src/PHP/CodeStandards/README.md
@@ -8,7 +8,7 @@
 - When you commit PHP code, pre-commit hook will check that your code follows the kununu standards, if not it will apply all
 the necessary changes to make it compliant.
 - You will need to add the files that were not compliant again to the git staging area and commit again.
-- In all this process you will be warn about the steps to take.
+- In all this process you will be warned about the steps to take.
 - In case you do not want to apply the changes on the code you can always use `--no-verify` option.
 
 ## Installation
@@ -52,7 +52,7 @@ git push --tags
 - If you want to install locally php-cs-fixer just:
 
 ```bash
-wget https://cs.symfony.com/download/php-cs-fixer-v2.phar -O php-cs-fixer
+wget https://cs.symfony.com/download/php-cs-fixer-v3.phar -O php-cs-fixer
 chmod a+x php-cs-fixer
 php-cs-fixer self-update
 sudo mv php-cs-fixer /usr/local/bin/php-cs-fixer

--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -10,37 +10,37 @@ return (new Config())
     ->setRiskyAllowed(true)
     ->setRules([
         // Import rule sets
-        '@Symfony'                              => true,
-        '@Symfony:risky'                        => true,
+        '@Symfony'                                         => true,
+        '@Symfony:risky'                                   => true,
         // Custom rules
-        'array_indentation'                     => true,
-        'binary_operator_spaces'                => [
+        'array_indentation'                                => true,
+        'binary_operator_spaces'                           => [
             'operators' => [
                 '=>' => 'align',
             ],
         ],
-        'blank_line_after_opening_tag'          => false,
-        'combine_consecutive_unsets'            => true,
-        'concat_space'                          => [
+        'blank_line_after_opening_tag'                     => false,
+        'combine_consecutive_unsets'                       => true,
+        'concat_space'                                     => [
             'spacing' => 'one',
         ],
-        'declare_strict_types'                  => true,
-        'echo_tag_syntax'                       => [
+        'declare_strict_types'                             => true,
+        'echo_tag_syntax'                                  => [
             'format' => 'long',
         ],
-        'function_declaration'                  => [
+        'function_declaration'                             => [
             'closure_function_spacing' => 'none',
             'closure_fn_spacing'       => 'none',
         ],
-        'global_namespace_import'               => [
+        'global_namespace_import'                          => [
             'import_classes' => true,
         ],
-        'heredoc_to_nowdoc'                     => true,
-        'increment_style'                       => [],
-        'method_chaining_indentation'           => false,
-        'native_constant_invocation'            => false,
-        'native_function_invocation'            => false,
-        'no_extra_blank_lines'                  => [
+        'heredoc_to_nowdoc'                                => true,
+        'increment_style'                                  => [],
+        'method_chaining_indentation'                      => false,
+        'native_constant_invocation'                       => false,
+        'native_function_invocation'                       => false,
+        'no_extra_blank_lines'                             => [
             'tokens' => [
                 'attribute',
                 'break',
@@ -57,12 +57,12 @@ return (new Config())
                 'use',
             ],
         ],
-        'no_superfluous_phpdoc_tags'            => false,
-        'no_trailing_whitespace_in_string'      => false,
-        'no_unreachable_default_argument_value' => true,
-        'no_useless_else'                       => true,
-        'no_useless_return'                     => true,
-        'ordered_imports'                       => [
+        'no_superfluous_phpdoc_tags'                       => false,
+        'no_trailing_whitespace_in_string'                 => false,
+        'no_unreachable_default_argument_value'            => true,
+        'no_useless_else'                                  => true,
+        'no_useless_return'                                => true,
+        'ordered_imports'                                  => [
             'imports_order'  => [
                 'class',
                 'function',
@@ -70,20 +70,21 @@ return (new Config())
             ],
             'sort_algorithm' => 'alpha',
         ],
-        'phpdoc_order'                          => true,
-        'phpdoc_summary'                        => false,
-        'return_assignment'                     => true,
-        'self_accessor'                         => false,
-        'self_static_accessor'                  => true,
-        'ternary_to_null_coalescing'            => true,
-        'visibility_required'                   => [
+        'phpdoc_order'                                     => true,
+        'phpdoc_summary'                                   => false,
+        'return_assignment'                                => true,
+        'self_accessor'                                    => false,
+        'self_static_accessor'                             => true,
+        'ternary_to_null_coalescing'                       => true,
+        'visibility_required'                              => [
             'elements' => [
                 'property',
                 'method',
             ],
         ],
-        'void_return'                           => true,
-        'yoda_style'                            => [],
+        'void_return'                                      => true,
+        'yoda_style'                                       => [],
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setFinder(
         Finder::create()

--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -1,4 +1,8 @@
 <?php
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
 
 // Usage
 // php-cs-fixer fix . --diff --dry-run --config=<path>/.php-cs-fixer.php -> [--dry-run (don't apply changes)] [--diff show differences]
@@ -6,54 +10,96 @@
 // php-cs-fixer fix application/Bootstrap.php --config=<path>/.php-cs-fixer.php -> it will apply only changes to a file or directory
 
 // Install:
-// wget https://cs.symfony.com/download/php-cs-fixer-v2.phar -O php-cs-fixer
+// wget https://cs.symfony.com/download/php-cs-fixer-v3.phar -O php-cs-fixer
 // chmod a+x php-cs-fixer
 // php-cs-fixer self-update
 // sudo mv php-cs-fixer /usr/local/bin/php-cs-fixer
 
-// Help on rules -> https://mlocati.github.io/php-cs-fixer-configurator/#
+// Help on rules -> https://cs.symfony.com/doc/rules/index.html
 
-$finder = PhpCsFixer\Finder::create()
-    ->exclude('vendor')
-    ->exclude('var')
-    ->in(__DIR__)
-;
-
-return (new PhpCsFixer\Config())
+return (new Config())
     ->setCacheFile('/tmp/.php-cs-fixer.php.cache')
     ->setRiskyAllowed(true)
     ->setRules([
-        '@Symfony' => true,
-        '@Symfony:risky' => true,
-        'combine_consecutive_unsets' => true,
-        'heredoc_to_nowdoc' => true,
-        'no_extra_blank_lines' => ['tokens' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block']],
-        'echo_tag_syntax' => ['format' => 'long'],
+        // Import rule sets
+        '@Symfony'                              => true,
+        '@Symfony:risky'                        => true,
+        // Custom rules
+        'array_indentation'                     => true,
+        'binary_operator_spaces'                => [
+            'operators' => [
+                '=>' => 'align',
+            ],
+        ],
+        'blank_line_after_opening_tag'          => false,
+        'combine_consecutive_unsets'            => true,
+        'concat_space'                          => [
+            'spacing' => 'one',
+        ],
+        'declare_strict_types'                  => true,
+        'echo_tag_syntax'                       => [
+            'format' => 'long',
+        ],
+        'function_declaration'                  => [
+            'closure_function_spacing' => 'none',
+            'closure_fn_spacing'       => 'none',
+        ],
+        'global_namespace_import'               => [
+            'import_classes' => true,
+        ],
+        'heredoc_to_nowdoc'                     => true,
+        'increment_style'                       => [],
+        'method_chaining_indentation'           => false,
+        'native_constant_invocation'            => false,
+        'native_function_invocation'            => false,
+        'no_extra_blank_lines'                  => [
+            'tokens' => [
+                'attribute',
+                'break',
+                'case',
+                'continue',
+                'curly_brace_block',
+                'default',
+                'extra',
+                'parenthesis_brace_block',
+                'return',
+                'square_brace_block',
+                'switch',
+                'throw',
+                'use',
+            ],
+        ],
+        'no_superfluous_phpdoc_tags'            => false,
+        'no_trailing_whitespace_in_string'      => false,
         'no_unreachable_default_argument_value' => true,
-        'no_useless_else' => true,
-        'no_useless_return' => true,
-        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
-        'phpdoc_order' => true,
-	    'global_namespace_import' => ['import_classes' => true],
-        'function_declaration' => ['closure_function_spacing' => 'none'],
-        'ternary_to_null_coalescing' => true,
-        'array_indentation' => true,
-        'blank_line_after_opening_tag' => false,
-        'self_accessor' => false,
-        'binary_operator_spaces' => ['operators' => ['=>' => 'align']],
-        'native_constant_invocation' => false,
-        'void_return' => true,
-        'concat_space' => ['spacing' => 'one'],
-        'native_function_invocation' => false,
-        'no_superfluous_phpdoc_tags' => false,
-        'yoda_style' => [],
-        'phpdoc_summary' => false,
-        'increment_style' => [],
-        'method_chaining_indentation' => false,
-        'visibility_required' => ['elements' => ['property', 'method']],
-        'self_static_accessor' => true,
-        'no_trailing_whitespace_in_string' => false,
-        'return_assignment' => true,
+        'no_useless_else'                       => true,
+        'no_useless_return'                     => true,
+        'ordered_imports'                       => [
+            'imports_order'  => [
+                'class',
+                'function',
+                'const',
+            ],
+            'sort_algorithm' => 'alpha',
+        ],
+        'phpdoc_order'                          => true,
+        'phpdoc_summary'                        => false,
+        'return_assignment'                     => true,
+        'self_accessor'                         => false,
+        'self_static_accessor'                  => true,
+        'ternary_to_null_coalescing'            => true,
+        'visibility_required'                   => [
+            'elements' => [
+                'property',
+                'method',
+            ],
+        ],
+        'void_return'                           => true,
+        'yoda_style'                            => [],
     ])
-    ->setFinder($finder)
-;
+    ->setFinder(
+        Finder::create()
+            ->exclude('vendor')
+            ->exclude('var')
+            ->in(__DIR__)
+    );

--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -84,7 +84,9 @@ return (new Config())
         ],
         'void_return'                                      => true,
         'yoda_style'                                       => [],
-        'nullable_type_declaration_for_default_null_value' => true,
+        'nullable_type_declaration_for_default_null_value' => [
+            'use_nullable_type_declaration' => true,
+        ],
     ])
     ->setFinder(
         Finder::create()

--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -4,19 +4,7 @@ declare(strict_types=1);
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
-// Usage
-// php-cs-fixer fix . --diff --dry-run --config=<path>/.php-cs-fixer.php -> [--dry-run (don't apply changes)] [--diff show differences]
-// php-cs-fixer fix application/ --config=<path>/.php-cs-fixer.php -> it will apply changes to all php files
-// php-cs-fixer fix application/Bootstrap.php --config=<path>/.php-cs-fixer.php -> it will apply only changes to a file or directory
-
-// Install:
-// wget https://cs.symfony.com/download/php-cs-fixer-v3.phar -O php-cs-fixer
-// chmod a+x php-cs-fixer
-// php-cs-fixer self-update
-// sudo mv php-cs-fixer /usr/local/bin/php-cs-fixer
-
 // Help on rules -> https://cs.symfony.com/doc/rules/index.html
-
 return (new Config())
     ->setCacheFile('/tmp/.php-cs-fixer.php.cache')
     ->setRiskyAllowed(true)


### PR DESCRIPTION
**Breaking changes**:
- Drop support for PHP 7.x and Composer 1.x
- Fix code standards :)
- Small refactors to use PHP 8.0 features
- Make rules files more readable
- Add no extra sapce rule for anonymous arrow functions