### PR TITLE
Remove single line rule on "throw Exception"

### DIFF
--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -87,6 +87,7 @@ return (new Config())
         'nullable_type_declaration_for_default_null_value' => [
             'use_nullable_type_declaration' => true,
         ],
+        'single_line_throw' => false,
     ])
     ->setFinder(
         Finder::create()


### PR DESCRIPTION
Our rules are based on Symfony rule set.

Symfony rule set has the `single_line_throw` option which enforces that all `throw new Exception` lines should be on a single line.

This PR will disable that rule.