### PR TITLE
Make PHP 8.3 the minimum supported version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.3",
     "composer-plugin-api": "^2.0",
     "friendsofphp/php-cs-fixer": "^3.0"
   },

--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -14,6 +14,9 @@ return (new Config())
         '@Symfony:risky'                                   => true,
         // Custom rules
         'array_indentation'                                => true,
+        'attribute_empty_parentheses'                      => [
+            'use_parentheses' => false,
+        ],
         'binary_operator_spaces'                           => [
             'operators' => [
                 '=>' => 'align',
@@ -87,7 +90,7 @@ return (new Config())
         'nullable_type_declaration_for_default_null_value' => [
             'use_nullable_type_declaration' => true,
         ],
-        'single_line_throw' => false,
+        'single_line_throw'                                => false,
     ])
     ->setFinder(
         Finder::create()


### PR DESCRIPTION
- Make PHP 8.3 the minimum supported version
- Add rule to remove empty parentheses on attributes