### PR TITLE
Remove binary_operator_spaces override for arrow align

### DIFF
--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -19,11 +19,6 @@ return (new Config())
         'attribute_empty_parentheses'                      => [
             'use_parentheses' => false,
         ],
-        'binary_operator_spaces'                           => [
-            'operators' => [
-                '=>' => 'align',
-            ],
-        ],
         'blank_line_after_opening_tag'                     => false,
         'combine_consecutive_unsets'                       => true,
         'concat_space'                                     => [


### PR DESCRIPTION
We are currently enforcing trailing commas, which are a good practice mainly to reduce diffs related to the last line of a multiline list, but we also have `binary_operator_space` for the `=>` operator set to `'align'`, which would cause the whole multiline list to be changed when the longest line changes.
 
As such it goes against the purpose of trailing commas and essentially negate any positive effect they might have in such lists.

This PR aims to fix that by removing the rule, thus falling back to the default indentation of a single space.