### PR TITLE
No strict yoda style will return, he will

### DIFF
--- a/src/PHP/CodeStandards/Scripts/php_cs
+++ b/src/PHP/CodeStandards/Scripts/php_cs
@@ -72,9 +72,9 @@ return (new Config())
         'void_return'                      => true,
         'yoda_style'                       => [
             'always_move_variable' => false,
-            'equal'                => false,
-            'identical'            => false,
-            'less_and_greater'     => false,
+            'equal'                => null,
+            'identical'            => null,
+            'less_and_greater'     => null,
         ],
     ])
     ->setFinder(


### PR DESCRIPTION
The last change here in #29 inadvertently introduced strict **no yoda style**, unnecessarily flipping all `true === $whatever` around.

We prefer to leave the behavior up to the projects, i.e. if yoda style leave it if not leave it too.

The documentation of php cs is officially 

```bash
  [yoda_style] Rule must be enabled (true), disabled (false) or configured (non-empty, assoc array). Other values are not allowed. To disable the rule, use "FALSE" instead of "NULL".
```

The configuration here is a more explicit version of `false`.